### PR TITLE
:recycle: Replace KIC -> CMC and KC in API spec

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -207,7 +207,7 @@ paths:
         required: false
         schema:
           type: string
-      - name: subjectVestigingVestigingsNummer
+      - name: subjectVestiging__vestigingsNummer
         in: query
         description: Een korte unieke aanduiding van de Vestiging.
         required: false
@@ -2067,7 +2067,9 @@ components:
 
             * `brc` - Besluitregistratiecomponent
 
-            * `kic` - Klantinteractiescomponent'
+            * `cmc` - Contactmomenten API
+
+            * `kc` - Klanten API'
           type: string
           enum:
           - ac
@@ -2076,7 +2078,8 @@ components:
           - ztc
           - drc
           - brc
-          - kic
+          - cmc
+          - kc
         requestId:
           title: Request id
           description: Een globaal "request" ID om een verzoek door het netwerk heen

--- a/src/resources.md
+++ b/src/resources.md
@@ -131,7 +131,8 @@ Uitleg bij mogelijke waarden:
 * `ztc` - Zaaktypecatalogus
 * `drc` - Documentregistratiecomponent
 * `brc` - Besluitregistratiecomponent
-* `kic` - Klantinteractiescomponent | string | ja | C​R​U​D |
+* `cmc` - Contactmomenten API
+* `kc` - Klanten API | string | ja | C​R​U​D |
 | requestId | Een globaal &quot;request&quot; ID om een verzoek door het netwerk heen te traceren. | string | nee | C​R​U​D |
 | applicatieId | Unieke identificatie van de applicatie, binnen de organisatie. | string | nee | C​R​U​D |
 | applicatieWeergave | Vriendelijke naam van de applicatie. | string | nee | C​R​U​D |

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -172,7 +172,7 @@
                         "type": "string"
                     },
                     {
-                        "name": "subjectVestigingVestigingsNummer",
+                        "name": "subjectVestiging__vestigingsNummer",
                         "in": "query",
                         "description": "Een korte unieke aanduiding van de Vestiging.",
                         "required": false,
@@ -2348,7 +2348,7 @@
                 },
                 "bron": {
                     "title": "Bron",
-                    "description": "De naam van het component waar de wijziging in is gedaan.\n\nUitleg bij mogelijke waarden:\n\n* `ac` - Autorisatiecomponent\n* `nrc` - Notificatierouteringcomponent\n* `zrc` - Zaakregistratiecomponent\n* `ztc` - Zaaktypecatalogus\n* `drc` - Documentregistratiecomponent\n* `brc` - Besluitregistratiecomponent\n* `kic` - Klantinteractiescomponent",
+                    "description": "De naam van het component waar de wijziging in is gedaan.\n\nUitleg bij mogelijke waarden:\n\n* `ac` - Autorisatiecomponent\n* `nrc` - Notificatierouteringcomponent\n* `zrc` - Zaakregistratiecomponent\n* `ztc` - Zaaktypecatalogus\n* `drc` - Documentregistratiecomponent\n* `brc` - Besluitregistratiecomponent\n* `cmc` - Contactmomenten API\n* `kc` - Klanten API",
                     "type": "string",
                     "enum": [
                         "ac",
@@ -2357,7 +2357,8 @@
                         "ztc",
                         "drc",
                         "brc",
-                        "kic"
+                        "cmc",
+                        "kc"
                     ]
                 },
                 "requestId": {


### PR DESCRIPTION
requires https://github.com/VNG-Realisatie/vng-api-common/pull/157 to be merged/released and vng-api-common to be bumped